### PR TITLE
Fix/avatar movement

### DIFF
--- a/src/apps/pixel-adventure/components/Avatar/Avatar.jsx
+++ b/src/apps/pixel-adventure/components/Avatar/Avatar.jsx
@@ -13,7 +13,11 @@ export default function Avatar() {
   const controller = useMovementController({
     onMove: (vel, dir) => {
       group.current.position.add(vel);
-      group.current.rotation.y = Math.atan2(dir.x, dir.z);
+
+      // rotation will use the last known direction, even after keys are released
+      if (dir.lengthSq() > 0) {
+        group.current.rotation.y = Math.atan2(dir.x, dir.z);
+      }
     },
     actions,
   });

--- a/src/apps/pixel-adventure/hooks/useMovementController.js
+++ b/src/apps/pixel-adventure/hooks/useMovementController.js
@@ -1,9 +1,9 @@
 import { useCallback, useEffect, useRef } from "react";
 import { Vector3 } from "three";
-import { useThree } from "@react-three/fiber";
 import AvatarActions, { JUMP_VELOCITY } from "../constants/avatar-actions.js";
 import { GRAVITY, GROUND_LEVEL } from "../constants/terrain-misc.js";
 import canEnterZone from "../utils/zones.js";
+import { useThree } from "@react-three/fiber";
 
 export default function useMovementController({ onMove, onJump, actions, completedZone = 0 }) {
   const { camera } = useThree();
@@ -84,9 +84,10 @@ export default function useMovementController({ onMove, onJump, actions, complet
     }
 
     // Movement logic
-    if (canEnterZone(nextX, nextZ, completedZone)) {
-      onMove?.(velocity.current, lastDir.current);
-    }
+    // if (canEnterZone(nextX, nextZ, completedZone)) {
+    //   onMove?.(velocity.current, lastDir.current);
+    // }
+    onMove?.(velocity.current, lastDir.current);
 
     // Animation control
     if (!isOnGround.current) {

--- a/src/apps/pixel-adventure/hooks/useMovementController.js
+++ b/src/apps/pixel-adventure/hooks/useMovementController.js
@@ -12,6 +12,7 @@ export default function useMovementController({ onMove, onJump, actions, complet
   const velocityY = useRef(0);
   const isOnGround = useRef(true);
   const currentAnim = useRef(null);
+  const lastDir = useRef(new Vector3(0, 0, 1)); // default forward facing
 
   const play = useCallback(
     (name) => {
@@ -52,6 +53,11 @@ export default function useMovementController({ onMove, onJump, actions, complet
     if (keys.current.get("KeyA")) direction.current.x -= 1;
     if (keys.current.get("KeyD")) direction.current.x += 1;
 
+    if (direction.current.lengthSq() > 0) {
+      direction.current.normalize();
+      lastDir.current.copy(direction.current);  // remember last input dir
+    }
+
     direction.current.normalize();
     velocity.current.copy(direction.current).multiplyScalar(delta);
 
@@ -72,10 +78,8 @@ export default function useMovementController({ onMove, onJump, actions, complet
 
     // Movement logic
     if (canEnterZone(nextX, nextZ, completedZone)) {
-      if (onMove) onMove(velocity.current, direction.current);
+      if (onMove) onMove(velocity.current, lastDir.current);
     }
-
-    // if (onMove) onMove(velocity.current, direction.current);
 
     // Animation control
     if (!isOnGround.current) {


### PR DESCRIPTION
- remember last direction
- use last known direction even after keys are released
- reference constant AvatarActions.JUMP
- temporarily disabled canEnterZone check on useMovementController